### PR TITLE
Move display_helpscreen and parse_console to core

### DIFF
--- a/src/char/CMakeLists.txt
+++ b/src/char/CMakeLists.txt
@@ -1,6 +1,6 @@
-add_executable(char-server)
+add_library(char)
 
-target_sources(char-server PRIVATE
+target_sources(char PRIVATE
 	"char.cpp"
 	"char_clif.cpp"
 	"char_cnslif.cpp"
@@ -22,7 +22,7 @@ target_sources(char-server PRIVATE
 )
 
 if(WIN32)
-	target_sources(char-server PRIVATE
+	target_sources(char PRIVATE
 		"char_clif.hpp"
 		"char_cnslif.hpp"
 		"char.hpp"
@@ -44,9 +44,12 @@ if(WIN32)
 		"packets.hpp"
 	)
 
-	set_target_properties(char-server PROPERTIES FOLDER "Servers")
+	set_target_properties(char PROPERTIES FOLDER "Servers")
 endif()
 
-target_link_libraries(char-server PUBLIC
+target_link_libraries(char PUBLIC
 	common
 )
+
+add_executable(char-server "CharacterServerMain.cpp")
+target_link_libraries(char-server PRIVATE char)

--- a/src/char/CharacterServerMain.cpp
+++ b/src/char/CharacterServerMain.cpp
@@ -1,0 +1,7 @@
+#include "char.hpp"
+
+using rathena::server_character::CharacterServer;
+
+int main(int argc, char *argv[]) {
+    return main_core<CharacterServer>(argc, argv);
+}

--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -3284,3 +3284,7 @@ void CharacterServer::displayHelpScreen(bool doExit) {
 		exit(EXIT_SUCCESS);
 	}
 }
+
+int32_t CharacterServer::parseConsole(const char* input) {
+	return parse_console(input);
+}

--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -3269,6 +3269,18 @@ bool CharacterServer::initialize( int32 argc, char *argv[] ){
 	return true;
 }
 
-int32 main( int32 argc, char *argv[] ){
-	return main_core<CharacterServer>( argc, argv );
+void CharacterServer::displayHelpScreen(bool doExit) {
+	ShowInfo("Usage: %s [options]\n", SERVER_NAME);
+	ShowInfo("\n");
+	ShowInfo("Options:\n");
+	ShowInfo("  -?, -h [--help]\t\tDisplays this help screen.\n");
+	ShowInfo("  -v [--version]\t\tDisplays the server's version.\n");
+	ShowInfo("  --run-once\t\t\tCloses server after loading (testing).\n");
+	ShowInfo("  --char-config <file>\t\tAlternative char-server configuration.\n");
+	ShowInfo("  --lan-config <file>\t\tAlternative lag configuration.\n");
+	ShowInfo("  --inter-config <file>\t\tAlternative inter-server configuration.\n");
+	ShowInfo("  --msg-config <file>\t\tAlternative message configuration.\n");
+	if (doExit) {
+		exit(EXIT_SUCCESS);
+	}
 }

--- a/src/char/char.hpp
+++ b/src/char/char.hpp
@@ -21,15 +21,16 @@ using rathena::server_core::e_core_type;
 
 namespace rathena::server_character {
 class CharacterServer : public Core {
-	protected:
-		bool initialize( int32 argc, char* argv[] ) override;
-		void finalize() override;
-		void handle_shutdown() override;
+protected:
+	bool initialize( int32 argc, char* argv[] ) override;
+	void finalize() override;
+	void handle_shutdown() override;
 
-	public:
-		CharacterServer() : Core( e_core_type::CHARACTER ){
+public:
+	CharacterServer() : Core( e_core_type::CHARACTER ){
 
-		}
+	}
+	void displayHelpScreen(bool doExit) override;
 };
 
 }

--- a/src/char/char.hpp
+++ b/src/char/char.hpp
@@ -31,6 +31,7 @@ public:
 
 	}
 	void displayHelpScreen(bool doExit) override;
+	int32_t parseConsole(const char* buf) override;
 };
 
 }

--- a/src/char/char_cnslif.cpp
+++ b/src/char/char_cnslif.cpp
@@ -14,25 +14,6 @@
 
 #include "char.hpp"
 
-/*======================================================
- * Login-Server help option info
- *------------------------------------------------------*/
-void display_helpscreen(bool do_exit)
-{
-	ShowInfo("Usage: %s [options]\n", SERVER_NAME);
-	ShowInfo("\n");
-	ShowInfo("Options:\n");
-	ShowInfo("  -?, -h [--help]\t\tDisplays this help screen.\n");
-	ShowInfo("  -v [--version]\t\tDisplays the server's version.\n");
-	ShowInfo("  --run-once\t\t\tCloses server after loading (testing).\n");
-	ShowInfo("  --char-config <file>\t\tAlternative char-server configuration.\n");
-	ShowInfo("  --lan-config <file>\t\tAlternative lag configuration.\n");
-	ShowInfo("  --inter-config <file>\t\tAlternative inter-server configuration.\n");
-	ShowInfo("  --msg-config <file>\t\tAlternative message configuration.\n");
-	if( do_exit )
-		exit(EXIT_SUCCESS);
-}
-
 /**
  * Timered function to check if the console has a new event to be read.
  * @param tid: timer id

--- a/src/common/cli.cpp
+++ b/src/common/cli.cpp
@@ -102,7 +102,7 @@ int32 cli_get_options(int32 argc, char ** argv) {
 			arg++;
 
 			if (strcmp(arg, "help") == 0) {
-				display_helpscreen(true);
+				global_core->displayHelpScreen(true);
 			}
 			else if (strcmp(arg, "version") == 0) {
 				display_versionscreen(true);
@@ -175,7 +175,7 @@ int32 cli_get_options(int32 argc, char ** argv) {
 			switch (arg[0]) {// short option
 				case '?':
 				case 'h':
-					display_helpscreen(true);
+					global_core->displayHelpScreen(true);
 					break;
 				case 'v':
 					display_versionscreen(true);

--- a/src/common/cli.cpp
+++ b/src/common/cli.cpp
@@ -221,7 +221,7 @@ TIMER_FUNC(parse_console_timer){
 		if(fgets(buf, MAX_CONSOLE_IN, stdin)==nullptr)
 			return -1;
 		else if(strlen(buf)>MIN_CONSOLE_IN)
-			parse_console(buf);
+			global_core->parseConsole(buf);
 	}
 	return 0;
 }

--- a/src/common/cli.hpp
+++ b/src/common/cli.hpp
@@ -26,7 +26,6 @@
  extern const char* LAN_CONF_NAME; //char-login
  extern const char* MSG_CONF_NAME_EN; //all
 
-extern void display_helpscreen(bool exit);
 bool cli_hasevent();
 void display_versionscreen(bool do_exit);
 bool opt_has_next_value(const char* option, int32 i, int32 argc);

--- a/src/common/cli.hpp
+++ b/src/common/cli.hpp
@@ -31,6 +31,5 @@ void display_versionscreen(bool do_exit);
 bool opt_has_next_value(const char* option, int32 i, int32 argc);
 int32 cli_get_options(int32 argc, char ** argv);
 TIMER_FUNC(parse_console_timer);
-extern int32 parse_console(const char* buf); //particular for each serv
 
 #endif /* CLI_HPP */

--- a/src/common/core.hpp
+++ b/src/common/core.hpp
@@ -90,6 +90,7 @@ public:
 	int32 start( int32 argc, char* argv[] );
 
 	virtual void displayHelpScreen(bool doExit) = 0;
+	virtual int32_t parseConsole(const char* buf) = 0; 
 };
 }
 

--- a/src/common/core.hpp
+++ b/src/common/core.hpp
@@ -78,6 +78,7 @@ public:
 		this->m_crashed = false;
 		this->m_type = type;
 	}
+	virtual ~Core() = default;
 
 	e_core_status get_status();
 	e_core_type get_type();
@@ -87,6 +88,8 @@ public:
 	void signal_crash();
 	void signal_shutdown();
 	int32 start( int32 argc, char* argv[] );
+
+	virtual void displayHelpScreen(bool doExit) = 0;
 };
 }
 

--- a/src/login/CMakeLists.txt
+++ b/src/login/CMakeLists.txt
@@ -29,7 +29,7 @@ target_link_libraries(login PUBLIC
 
 # common depends on login for the implementations of some functions
 # TODO Remove this circular dependency by refactoring those functions into Core::<func> and overriding them
-target_link_libraries(common PUBLIC login)
+# target_link_libraries(common PUBLIC login)
 
 add_executable(login-server "LoginServerMain.cpp")
 target_link_libraries(login-server PRIVATE login)

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -1015,3 +1015,7 @@ void LoginServer::displayHelpScreen(bool doExit) {
 		exit(EXIT_SUCCESS);
 	}
 }
+
+int32_t LoginServer::parseConsole(const char* input) {
+	return parse_console(input);
+}

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -1000,3 +1000,18 @@ bool LoginServer::initialize( int32 argc, char* argv[] ){
 AccountDb* LoginServer::getAccountDb() {
 	return accountDb_.get();
 }
+
+void LoginServer::displayHelpScreen(bool doExit) {
+	ShowInfo("Usage: %s [options]\n", SERVER_NAME);
+	ShowInfo("\n");
+	ShowInfo("Options:\n");
+	ShowInfo("  -?, -h [--help]\t\tDisplays this help screen.\n");
+	ShowInfo("  -v [--version]\t\tDisplays the server's version.\n");
+	ShowInfo("  --run-once\t\t\tCloses server after loading (testing).\n");
+	ShowInfo("  --login-config <file>\t\tAlternative login-server configuration.\n");
+	ShowInfo("  --lan-config <file>\t\tAlternative lan configuration.\n");
+	ShowInfo("  --msg-config <file>\t\tAlternative message configuration.\n");
+	if (doExit) {
+		exit(EXIT_SUCCESS);
+	}
+}

--- a/src/login/login.hpp
+++ b/src/login/login.hpp
@@ -29,6 +29,7 @@ public:
 	}
 
 	AccountDb* getAccountDb();
+	void displayHelpScreen(bool exit) override;
 private:
 	std::unique_ptr<AccountDb> accountDb_{nullptr};
 };

--- a/src/login/login.hpp
+++ b/src/login/login.hpp
@@ -30,6 +30,7 @@ public:
 
 	AccountDb* getAccountDb();
 	void displayHelpScreen(bool exit) override;
+	int32_t parseConsole(const char* buf) override;
 private:
 	std::unique_ptr<AccountDb> accountDb_{nullptr};
 };

--- a/src/login/logincnslif.cpp
+++ b/src/login/logincnslif.cpp
@@ -16,25 +16,6 @@
 #include "login.hpp"
 
 /**
- * Login-server console help: starting option info.
- *  Do not rename function used as extern.
- * @param do_exit: terminate program execution ?
- */
-void display_helpscreen(bool do_exit) {
-	ShowInfo("Usage: %s [options]\n", SERVER_NAME);
-	ShowInfo("\n");
-	ShowInfo("Options:\n");
-	ShowInfo("  -?, -h [--help]\t\tDisplays this help screen.\n");
-	ShowInfo("  -v [--version]\t\tDisplays the server's version.\n");
-	ShowInfo("  --run-once\t\t\tCloses server after loading (testing).\n");
-	ShowInfo("  --login-config <file>\t\tAlternative login-server configuration.\n");
-	ShowInfo("  --lan-config <file>\t\tAlternative lan configuration.\n");
-	ShowInfo("  --msg-config <file>\t\tAlternative message configuration.\n");
-	if( do_exit )
-		exit(EXIT_SUCCESS);
-}
-
-/**
  * Console Command Parser
  * Transmited from command cli.cpp
  * note common name for all serv do not rename (extern in cli)

--- a/src/map/CMakeLists.txt
+++ b/src/map/CMakeLists.txt
@@ -227,32 +227,35 @@ set(MAP_HEADERS
 	"skills/thief/stonefling.hpp"
 )
 
-add_executable(map-server)
+add_library(map)
 
-target_sources(map-server PRIVATE ${MAP_SOURCES})
+target_sources(map PRIVATE ${MAP_SOURCES})
 
 if(WIN32)
-	target_sources(map-server PRIVATE ${MAP_HEADERS})
-	set_target_properties(map-server PROPERTIES FOLDER "Servers")
+	target_sources(map PRIVATE ${MAP_HEADERS})
+	set_target_properties(map PROPERTIES FOLDER "Servers")
 endif()
 
-target_link_libraries(map-server PUBLIC
+target_link_libraries(map PUBLIC
 	common
 	${PCRE_LIBRARIES}
 )
 
-target_include_directories(map-server PUBLIC
+target_include_directories(map PUBLIC
 	${PCRE_INCLUDE_DIRS}
 )
 
 if(WITH_PCRE)
-	target_compile_definitions(map-server PUBLIC "PCRE_SUPPORT")
+	target_compile_definitions(map PUBLIC "PCRE_SUPPORT")
 endif()
 
-# map-server-generator
-add_executable(map-server-generator)
+add_executable(map-server "MapServerMain.cpp")
+target_link_libraries(map-server PRIVATE map)
 
-target_sources(map-server-generator PRIVATE ${MAP_SOURCES})
+# map-server-generator
+add_library(map-server-generator)
+
+target_sources(map-server-generator PRIVATE ${MAP_SOURCES} "MapServerGeneratorMain.cpp")
 
 if(WIN32)
 	target_sources(map-server-generator PRIVATE ${MAP_HEADERS})

--- a/src/map/MapServerGeneratorMain.cpp
+++ b/src/map/MapServerGeneratorMain.cpp
@@ -1,0 +1,7 @@
+#include "map.hpp"
+
+using rathena::server_map::MapServer;
+
+int main(int argc, char *argv[]) {
+    return main_core<MapServer>(argc, argv);
+}

--- a/src/map/MapServerMain.cpp
+++ b/src/map/MapServerMain.cpp
@@ -1,0 +1,7 @@
+#include "map.hpp"
+
+using rathena::server_map::MapServer;
+
+int main(int argc, char *argv[]) {
+    return main_core<MapServer>(argc, argv);
+}

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -5149,29 +5149,6 @@ void MapServer::handle_crash(){
 }
 
 /*======================================================
- * Map-Server help options screen
- *------------------------------------------------------*/
-void display_helpscreen(bool do_exit)
-{
-	ShowInfo("Usage: %s [options]\n", SERVER_NAME);
-	ShowInfo("\n");
-	ShowInfo("Options:\n");
-	ShowInfo("  -?, -h [--help]\t\tDisplays this help screen.\n");
-	ShowInfo("  -v [--version]\t\tDisplays the server's version.\n");
-	ShowInfo("  --run-once\t\t\tCloses server after loading (testing).\n");
-	ShowInfo("  --map-config <file>\t\tAlternative map-server configuration.\n");
-	ShowInfo("  --battle-config <file>\tAlternative battle configuration.\n");
-	ShowInfo("  --atcommand-config <file>\tAlternative atcommand configuration.\n");
-	ShowInfo("  --script-config <file>\tAlternative script configuration.\n");
-	ShowInfo("  --msg-config <file>\t\tAlternative message configuration.\n");
-	ShowInfo("  --grf-path <file>\t\tAlternative GRF path configuration.\n");
-	ShowInfo("  --inter-config <file>\t\tAlternative inter-server configuration.\n");
-	ShowInfo("  --log-config <file>\t\tAlternative logging configuration.\n");
-	if( do_exit )
-		exit(EXIT_SUCCESS);
-}
-
-/*======================================================
  * Message System
  *------------------------------------------------------*/
 struct msg_data {
@@ -5485,6 +5462,22 @@ bool MapServer::initialize( int32 argc, char *argv[] ){
 	return true;
 }
 
-int32 main( int32 argc, char *argv[] ){
-	return main_core<MapServer>( argc, argv );
+void MapServer::displayHelpScreen(bool doExit) {
+	ShowInfo("Usage: %s [options]\n", SERVER_NAME);
+	ShowInfo("\n");
+	ShowInfo("Options:\n");
+	ShowInfo("  -?, -h [--help]\t\tDisplays this help screen.\n");
+	ShowInfo("  -v [--version]\t\tDisplays the server's version.\n");
+	ShowInfo("  --run-once\t\t\tCloses server after loading (testing).\n");
+	ShowInfo("  --map-config <file>\t\tAlternative map-server configuration.\n");
+	ShowInfo("  --battle-config <file>\tAlternative battle configuration.\n");
+	ShowInfo("  --atcommand-config <file>\tAlternative atcommand configuration.\n");
+	ShowInfo("  --script-config <file>\tAlternative script configuration.\n");
+	ShowInfo("  --msg-config <file>\t\tAlternative message configuration.\n");
+	ShowInfo("  --grf-path <file>\t\tAlternative GRF path configuration.\n");
+	ShowInfo("  --inter-config <file>\t\tAlternative inter-server configuration.\n");
+	ShowInfo("  --log-config <file>\t\tAlternative logging configuration.\n");
+	if (doExit) {
+		exit(EXIT_SUCCESS);
+	}
 }

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -5481,3 +5481,7 @@ void MapServer::displayHelpScreen(bool doExit) {
 		exit(EXIT_SUCCESS);
 	}
 }
+
+int32_t MapServer::parseConsole(const char* input) {
+	return parse_console(input);
+}

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -29,16 +29,17 @@ using rathena::server_core::e_core_type;
 
 namespace rathena::server_map {
 class MapServer : public Core{
-	protected:
-		bool initialize( int32 argc, char* argv[] ) override;
-		void finalize() override;
-		void handle_crash() override;
-		void handle_shutdown() override;
+protected:
+	bool initialize( int32 argc, char* argv[] ) override;
+	void finalize() override;
+	void handle_crash() override;
+	void handle_shutdown() override;
 
-	public:
-		MapServer() : Core( e_core_type::MAP ){
+public:
+	MapServer() : Core( e_core_type::MAP ){
 
-		}
+	}
+	void displayHelpScreen(bool doExit) override;
 };
 }
 

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -40,6 +40,7 @@ public:
 
 	}
 	void displayHelpScreen(bool doExit) override;
+	int32_t parseConsole(const char* buf) override;
 };
 }
 

--- a/src/web/CMakeLists.txt
+++ b/src/web/CMakeLists.txt
@@ -1,9 +1,9 @@
-add_executable(web-server)
+add_library(web)
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
-target_sources(web-server PRIVATE
+target_sources(web PRIVATE
 	"auth.cpp"
 	"charconfig_controller.cpp"
 	"emblem_controller.cpp"
@@ -16,7 +16,7 @@ target_sources(web-server PRIVATE
 )
 
 if(WIN32)
-	target_sources(web-server PRIVATE
+	target_sources(web PRIVATE
 		"auth.hpp"
 		"charconfig_controller.hpp"
 		"emblem_controller.hpp"
@@ -30,12 +30,15 @@ if(WIN32)
 		"webutils.hpp"
 	)
 
-	set_target_properties(web-server PROPERTIES FOLDER "Servers")
+	set_target_properties(web PROPERTIES FOLDER "Servers")
 endif()
 
-target_link_libraries(web-server PUBLIC
+target_link_libraries(web PUBLIC
 	common
 	httplib
 	Threads::Threads
 	json
 )
+
+add_executable(web-server "WebServerMain.cpp")
+target_link_libraries(web-server PRIVATE web)

--- a/src/web/WebServerMain.cpp
+++ b/src/web/WebServerMain.cpp
@@ -1,0 +1,8 @@
+#include "web.hpp"
+
+using rathena::server_web::WebServer;
+
+
+int main(int argc, char *argv[]) {
+	return main_core<WebServer>(argc, argv);
+}

--- a/src/web/web.cpp
+++ b/src/web/web.cpp
@@ -500,3 +500,7 @@ void WebServer::displayHelpScreen(bool doExit) {
 		exit(EXIT_SUCCESS);
 	}
 }
+
+int32_t WebServer::parseConsole(const char* input) {
+	return parse_console(input);
+}

--- a/src/web/web.cpp
+++ b/src/web/web.cpp
@@ -494,6 +494,9 @@ void WebServer::handle_main( t_tick next ){
 	std::this_thread::sleep_for( std::chrono::milliseconds( next ) );
 }
 
-int32 main( int32 argc, char *argv[] ){
-	return main_core<WebServer>( argc, argv );
+void WebServer::displayHelpScreen(bool doExit) {
+	ShowInfo("Usage: %s\n", SERVER_NAME);
+	if (doExit) {
+		exit(EXIT_SUCCESS);
+	}
 }

--- a/src/web/web.hpp
+++ b/src/web/web.hpp
@@ -28,6 +28,7 @@ public:
 
 	}
 	void displayHelpScreen(bool doExit) override;
+	int32_t parseConsole(const char* buf) override;
 };
 }
 

--- a/src/web/web.hpp
+++ b/src/web/web.hpp
@@ -17,16 +17,17 @@ using rathena::server_core::e_core_type;
 
 namespace rathena::server_web {
 class WebServer : public Core{
-	protected:
-		bool initialize( int32 argc, char* argv[] ) override;
-		void handle_main( t_tick next ) override;
-		void finalize() override;
-		void handle_crash() override;
+protected:
+	bool initialize( int32 argc, char* argv[] ) override;
+	void handle_main( t_tick next ) override;
+	void finalize() override;
+	void handle_crash() override;
 
-	public:
-		WebServer() : Core( e_core_type::WEB ){
+public:
+	WebServer() : Core( e_core_type::WEB ){
 
-		}
+	}
+	void displayHelpScreen(bool doExit) override;
 };
 }
 


### PR DESCRIPTION
These were previously declared `extern` in common, and then implemented in the different servers
Let's move it to core

Also move the main functions to their own files, and load the servers as libraries