### PR TITLE
Remove extern from functions, not needed

### DIFF
--- a/src/common/core.hpp
+++ b/src/common/core.hpp
@@ -28,7 +28,6 @@ extern char *SERVER_NAME;
 extern char db_path[12]; /// relative path for db from servers
 extern char conf_path[12]; /// relative path for conf from servers
 
-extern int32 parse_console(const char* buf);
 const char *get_svn_revision(void);
 const char *get_git_hash(void);
 

--- a/src/common/showmsg.hpp
+++ b/src/common/showmsg.hpp
@@ -87,17 +87,17 @@ enum msg_type {
 	MSG_FATALERROR
 };
 
-extern void ClearScreen(void);
-extern int32 _vShowMessage(enum msg_type flag, const char *string, va_list ap);
-extern void ShowMessage(const char *, ...);
-extern void ShowStatus(const char *, ...);
-extern void ShowSQL(const char *, ...);
-extern void ShowInfo(const char *, ...);
-extern void ShowNotice(const char *, ...);
-extern void ShowWarning(const char *, ...);
-extern void ShowDebug(const char *, ...);
-extern void ShowError(const char *, ...);
-extern void ShowFatalError(const char *, ...);
-extern void ShowConfigWarning(config_setting_t *config, const char *string, ...);
+void ClearScreen(void);
+int32 _vShowMessage(enum msg_type flag, const char *string, va_list ap);
+void ShowMessage(const char *, ...);
+void ShowStatus(const char *, ...);
+void ShowSQL(const char *, ...);
+void ShowInfo(const char *, ...);
+void ShowNotice(const char *, ...);
+void ShowWarning(const char *, ...);
+void ShowDebug(const char *, ...);
+void ShowError(const char *, ...);
+void ShowFatalError(const char *, ...);
+void ShowConfigWarning(config_setting_t *config, const char *string, ...);
 
 #endif /* SHOWMSG_HPP */

--- a/src/common/socket.hpp
+++ b/src/common/socket.hpp
@@ -125,8 +125,8 @@ extern time_t stall_time;
 
 //////////////////////////////////
 // some checking on sockets
-extern bool session_isValid(int32 fd);
-extern bool session_isActive(int32 fd);
+bool session_isValid(int32 fd);
+bool session_isActive(int32 fd);
 //////////////////////////////////
 
 // Function prototype declaration
@@ -145,9 +145,9 @@ void do_close(int32 fd);
 void socket_init(void);
 void socket_final(void);
 
-extern void flush_fifo(int32 fd);
-extern void flush_fifos(void);
-extern void set_nonblocking(int32 fd, unsigned long yes);
+void flush_fifo(int32 fd);
+void flush_fifos(void);
+void set_nonblocking(int32 fd, unsigned long yes);
 
 void set_defaultparse(ParseFunc defaultparse);
 

--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -33,19 +33,19 @@ uint32 get_percentage_exp(const uint64 a, const uint64 b);
 // byte word dword access [Shinomori]
 //////////////////////////////////////////////////////////////////////////
 
-extern uint8 GetByte(uint32 val, int32 idx);
-extern uint16 GetWord(uint32 val, int32 idx);
-extern uint16 MakeWord(uint8 byte0, uint8 byte1);
-extern uint32 MakeDWord(uint16 word0, uint16 word1);
+uint8 GetByte(uint32 val, int32 idx);
+uint16 GetWord(uint32 val, int32 idx);
+uint16 MakeWord(uint8 byte0, uint8 byte1);
+uint32 MakeDWord(uint16 word0, uint16 word1);
 
 //////////////////////////////////////////////////////////////////////////
 // Big-endian compatibility functions
 //////////////////////////////////////////////////////////////////////////
-extern int16 MakeShortLE(int16 val);
-extern int32 MakeLongLE(int32 val);
-extern uint16 GetUShort(const unsigned char* buf);
-extern uint32 GetULong(const unsigned char* buf);
-extern int32 GetLong(const unsigned char* buf);
-extern float GetFloat(const unsigned char* buf);
+int16 MakeShortLE(int16 val);
+int32 MakeLongLE(int32 val);
+uint16 GetUShort(const unsigned char* buf);
+uint32 GetULong(const unsigned char* buf);
+int32 GetLong(const unsigned char* buf);
+float GetFloat(const unsigned char* buf);
 
 #endif /* UTILS_HPP */

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -789,8 +789,8 @@ extern struct Battle_Config battle_config;
 
 void do_init_battle(void);
 void do_final_battle(void);
-extern int32 battle_config_read(const char *cfgName);
-extern void battle_set_defaults(void);
+int32 battle_config_read(const char *cfgName);
+void battle_set_defaults(void);
 int32 battle_set_value(const char* w1, const char* w2);
 int32 battle_get_value(const char* w1);
 


### PR DESCRIPTION
parse_console and display_helpscreen were the only ones that required it, but now they're gone.